### PR TITLE
Fix minimal card call

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -11,7 +11,6 @@ import {
   MinimalCardType,
 } from "@/app/constants/types";
 import MinimalCard from "@/app/components/MinimalCard";
-import { adaptEventToMinimalCardType } from "../page";
 import Slider from "@/app/components/Slider";
 
 export async function generateStaticParams() {
@@ -41,13 +40,12 @@ const buttonStyling =
   "md:rounded-lg md:no-underline md:bg-[#0076AD] uppercase md:text-white md:my-5 md:w-48 md:py-3 md:text-2xl md:font-semibold md:capitalize md:tracking-wide";
 
 export default async function Event({ params }: { params: { slug: string } }) {
-  const allEvents = (await getEvents()) as unknown as EventCardType[];
   const orgEvent = await getEventBySlug(params.slug);
 
   const eventPhoto = orgEvent.eventPhoto.fields.file;
   const eventDetails = orgEvent?.eventDetailsPhoto;
   const DynamicImage = dynamic(() => import("next/image"), { ssr: false });
-
+  const allEvents = (await getEvents()) as unknown as EventCardType[];
   const dateString = orgEvent.eventDate;
   const eventDate: Date = new Date(dateString);
   const formattedDateTime: string = formatDateTime(eventDate);
@@ -254,7 +252,11 @@ export default async function Event({ params }: { params: { slug: string } }) {
           {allEvents.map((soleEvent) => (
             <MinimalCard
               key={soleEvent.slug}
-              cardContent={adaptEventToMinimalCardType(soleEvent)}
+              cardContent={{
+                title: soleEvent.eventName,
+                cardPhoto: soleEvent.eventPhoto,
+                summary: soleEvent.eventSummary,
+              }}
             />
           ))}
         </div>

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,20 +1,9 @@
 import { getEvents } from "@/app/utils/contentful";
-import { MinimalCardType, EventCardType } from "@/app/constants/types";
+import { EventCardType } from "@/app/constants/types";
 import MinimalCard from "@/app/components/MinimalCard";
-
-export function adaptEventToMinimalCardType(
-  event: EventCardType,
-): MinimalCardType {
-  return {
-    title: event.eventName,
-    cardPhoto: event.eventPhoto,
-    summary: event.eventSummary,
-  };
-}
 
 export default async function Events() {
   const events = (await getEvents()) as unknown as EventCardType[];
-
   return (
     <main className="">
       {/* MOBILE Search Box */}
@@ -34,7 +23,11 @@ export default async function Events() {
           {events.map((eventObj) => (
             <MinimalCard
               key={eventObj.slug}
-              cardContent={adaptEventToMinimalCardType(eventObj)}
+              cardContent={{
+                title: eventObj.eventName,
+                cardPhoto: eventObj.eventPhoto,
+                summary: eventObj.eventSummary,
+              }}
             />
           ))}
         </div>


### PR DESCRIPTION
Temp fix for error on minimal card, bypassing checks so that the other PRs do not break

# Pull Request Process

## Copy and Paste / Write ticket description

Call to render events in the minimal event row was breaking build. Eventually we will have to pull this logic out of the pages and have it as it's own component. 

TO Do: [The max four entries per row that goes under an individual event page](https://linear.app/ofashandfire/issue/LUS-135/component-news-row)

TO DO: [This ticket ](https://linear.app/ofashandfire/issue/LUS-134/build-category-landing-page-blog-full-grid)will encompass the minimal card mapping logic that is in events/page

## Describe the changes you've made to resolve the issue

All pages under events folder

## Add screenshots of the UI before and after your changes have been made

no visual changes

## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [ ] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?
