### PR TITLE
Add news row to news/slug, corporate-sponsorhip, patient-stories/slug

### DIFF
--- a/app/corporate-sponsorship/page.tsx
+++ b/app/corporate-sponsorship/page.tsx
@@ -1,15 +1,20 @@
 import PageSection from "@/app/components/PageSection/PageSection";
-import { PageSectionType } from "@/app/constants/types";
-import { getPageByType } from "@/app/utils/contentful";
+import { BlogCardsRowType, PageSectionType } from "@/app/constants/types";
+import { getNewsPosts, getPageByType } from "@/app/utils/contentful";
 import { PAGE_TYPES } from "@/app/constants/entries";
+import BlogCardsRow from "../components/BlogCardsRow";
 
 export default async function CorporateSponsorship() {
   const page = await getPageByType(PAGE_TYPES.CORPORATE_SPONSORSHIP);
+  const news = (await getNewsPosts(4)) as unknown as BlogCardsRowType[];
   return (
     <main>
       {page.pageSections.map((section: PageSectionType) => (
         <PageSection key={section.fields.title} section={section} />
       ))}
+      <section className="flex justify-center">
+        <BlogCardsRow type="news" cards={news} />
+      </section>
     </main>
   );
 }

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -2,8 +2,9 @@ import Image from "next/image";
 import { getNewsPosts, getNewsPostBySlug } from "@/app/utils/contentful";
 import renderRichTextToReactComponent from "@/app/utils/rich-text";
 import PageSection from "@/app/components/PageSection/PageSection";
-import { PageSectionType } from "@/app/constants/types";
+import { BlogCardsRowType, PageSectionType } from "@/app/constants/types";
 import SocialMediaSection from "@/app/components/SocialMediaSection";
+import BlogCardsRow from "@/app/components/BlogCardsRow";
 
 export async function generateStaticParams() {
   const newsPosts = await getNewsPosts();
@@ -25,6 +26,7 @@ export default async function NewsArticle({
   params: { slug: string };
 }) {
   const newsPost = await getNewsPostBySlug(params.slug);
+  const news = (await getNewsPosts(4)) as unknown as BlogCardsRowType[];
 
   const {
     title,
@@ -82,6 +84,9 @@ export default async function NewsArticle({
         {pageSections.map((section: PageSectionType) => (
           <PageSection key={section.fields.title} section={section} />
         ))}
+      </section>
+      <section className="mx-auto">
+        <BlogCardsRow type="news" cards={news} />
       </section>
     </main>
   );

--- a/app/patient-stories/[slug]/page.tsx
+++ b/app/patient-stories/[slug]/page.tsx
@@ -1,10 +1,12 @@
 import TwoColumnLayout from "@/app/components/PageSection/ColumnsLayout/TwoColumnLayout";
 import {
+  getNewsPosts,
   getPatientStories,
   getPatientStoryBySlug,
 } from "@/app/utils/contentful";
 import PageSection from "@/app/components/PageSection/PageSection";
-import { PageSectionType } from "@/app/constants/types";
+import { BlogCardsRowType, PageSectionType } from "@/app/constants/types";
+import BlogCardsRow from "@/app/components/BlogCardsRow";
 
 export async function generateStaticParams() {
   const patients = await getPatientStories();
@@ -17,6 +19,8 @@ export default async function PatientStories({
   params: { slug: string };
 }) {
   const patient = await getPatientStoryBySlug(params.slug);
+  const news = (await getNewsPosts(4)) as unknown as BlogCardsRowType[];
+
   return (
     <main>
       <TwoColumnLayout section={patient.topSection} />
@@ -24,6 +28,9 @@ export default async function PatientStories({
         patient.pageSections.map((pageSection: PageSectionType) => (
           <PageSection key={pageSection.fields.title} section={pageSection} />
         ))}
+      <section className="flex justify-center">
+        <BlogCardsRow type="news" cards={news} />
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
# Pull Request Process

Adds 4 most recent news row bottom component to 

patient-stories/slug
news/slug
corporate-sponsorship/slug

## Describe the changes you've made to resolve the issue

Imported BlogCardsRow, with 4 entries from News

## Add screenshots of the UI before and after your changes have been made

<!-- You should have 2 images minimum, for desktop, 4 for mobile and desktop combined -->

### Before
none

### After
<img width="500" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/c4fff12e-5a6a-44d7-b1e2-020d18ee2eb7">


## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [ ] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?
