### PR TITLE
Hide mobile search icon until implemented

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -12,7 +12,9 @@ import {
 } from "@/components/ui/navigation-menu";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faMagnifyingGlass, faBars } from "@fortawesome/free-solid-svg-icons";
+import { faBars } from "@fortawesome/free-solid-svg-icons";
+// import { faMagnifyingGlass,} from "@fortawesome/free-solid-svg-icons";
+
 
 import Button from "@/app/components/ui/Button";
 import { DONATE_URL, MYCHART_URL, SAVE_MY_SPOT } from "../constants/links";
@@ -142,11 +144,9 @@ export default function Navbar() {
 
         {/* To be implemented later*/}
         <NavigationMenuItem className="list-none">
-          {/* <button className="bg-transparent text-white rounded-full p-3 text-xl"> */}
-            {" "}
-            {/* <FontAwesomeIcon icon={faMagnifyingGlass} /> */}
+          {/* <button className="bg-transparent text-white rounded-full p-3 text-xl"> */}{" "}
+          {/* <FontAwesomeIcon icon={faMagnifyingGlass} /> */}
           {/* </button> */}
-
           <button
             onClick={toggleHamburgerDropdown}
             className="bg-transparent text-white rounded-full py-3 px-4 text-xl"

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -140,12 +140,12 @@ export default function Navbar() {
           </Link>
         </div>
 
+        {/* To be implemented later*/}
         <NavigationMenuItem className="list-none">
-          <button className="bg-transparent text-white rounded-full p-3 text-xl">
+          {/* <button className="bg-transparent text-white rounded-full p-3 text-xl"> */}
             {" "}
-            {/* Increase padding and font size */}
-            <FontAwesomeIcon icon={faMagnifyingGlass} />
-          </button>
+            {/* <FontAwesomeIcon icon={faMagnifyingGlass} /> */}
+          {/* </button> */}
 
           <button
             onClick={toggleHamburgerDropdown}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -15,7 +15,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBars } from "@fortawesome/free-solid-svg-icons";
 // import { faMagnifyingGlass,} from "@fortawesome/free-solid-svg-icons";
 
-
 import Button from "@/app/components/ui/Button";
 import { DONATE_URL, MYCHART_URL, SAVE_MY_SPOT } from "../constants/links";
 import NavbarDropdown from "@/app/components/NavbarDropdown";


### PR DESCRIPTION
Addresses: https://linear.app/ofashandfire/issue/LUS-219/temp-hide-search-icon

- [ X] Temporarily hide mobile search icon

## Describe the changes you've made to resolve the issue

Navbar.tsx 

## Add screenshots of the UI before and after your changes have been made

### Before

<img width="583" alt="Screenshot 2024-01-23 at 10 44 47 AM" src="https://github.com/LuskinOIC/website/assets/84194997/e56d8e97-c8a9-4d3f-b6be-9a991851bfdf">

### After
<img width="588" alt="Screenshot 2024-01-23 at 10 47 44 AM" src="https://github.com/LuskinOIC/website/assets/84194997/00cb0ed4-f5c6-4c3b-823f-00a6259e2f64">


## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [ ] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?
