### PR TITLE
Info card image sizing

### DIFF
--- a/app/components/PageSection/InfoCardLayout.tsx
+++ b/app/components/PageSection/InfoCardLayout.tsx
@@ -35,14 +35,12 @@ export default function InfoCardLayout({ section }: { section: CardType[] }) {
             key={i}
             className="col-span-1 rounded-[10px] shadow-lg border border-black border-opacity-10 pb-8 md:p-10 overflow-hidden"
           >
-            <div className="relative md:rounded-[10px] overflow-hidden">
+            <div className="relative md:rounded-[10px] overflow-hidden h-[250px] w-full">
               <Image
                 className="object-cover"
                 src={`https:${card.fields.image.fields.file.url}`}
                 alt={card.fields.image.fields.description}
-                style={{ width: "100%", height: "auto" }}
-                width={500}
-                height={400}
+                layout="fill"
               />
             </div>
             <div className="md:h-min-[242px] px-5 md:px-0 flex-col ">

--- a/app/components/PageSection/InfoCardLayout.tsx
+++ b/app/components/PageSection/InfoCardLayout.tsx
@@ -35,13 +35,13 @@ export default function InfoCardLayout({ section }: { section: CardType[] }) {
             key={i}
             className="flex flex-col col-span-1 rounded-[10px] shadow-lg border border-black border-opacity-10 pb-8 md:p-10 overflow-hidden"
           >
-            <div className="relative md:rounded-[10px] overflow-hidden h-[350px] w-7/8 mx-auto">
+            <div className="relative md:rounded-[10px] overflow-hidden h-[300px] md:h-[325px] w-7/8 mx-auto">
               <Image
-                className="w-full h-full object-cover"
+                className="w-full h-full object-cover rounded-[10px]"
                 src={`https:${card.fields.image.fields.file.url}`}
                 alt={card.fields.image.fields.description}
-                width={500}
-                height={400}
+                width={400}
+                height={300}
               />
             </div>
             <div className="flex-grow px-5 md:px-0 ">

--- a/app/components/PageSection/InfoCardLayout.tsx
+++ b/app/components/PageSection/InfoCardLayout.tsx
@@ -37,7 +37,7 @@ export default function InfoCardLayout({ section }: { section: CardType[] }) {
           >
             <div className="relative md:rounded-[10px] overflow-hidden h-[300px] md:h-[325px] w-7/8 mx-auto">
               <Image
-                className="w-full h-full object-cover rounded-[10px]"
+                className="w-full h-full object-cover rounded-t-lg md:rounded-[10px]"
                 src={`https:${card.fields.image.fields.file.url}`}
                 alt={card.fields.image.fields.description}
                 width={400}

--- a/app/components/PageSection/InfoCardLayout.tsx
+++ b/app/components/PageSection/InfoCardLayout.tsx
@@ -28,22 +28,23 @@ export function InfoCardContent(cardContent: TextType) {
 
 export default function InfoCardLayout({ section }: { section: CardType[] }) {
   return (
-    <section className="grid md:grid-cols-2 gap-6 md:m-auto justify-items-center md:w-[80%] px-2 py-8 md:py-10">
+    <section className="grid md:grid-cols-2 gap-6 md:m-auto justify-items-stretch md:w-[80%] px-2 py-8 md:py-10">
       {section.map((card, i) => {
         return (
           <div
             key={i}
-            className="col-span-1 rounded-[10px] shadow-lg border border-black border-opacity-10 pb-8 md:p-10 overflow-hidden"
+            className="flex flex-col col-span-1 rounded-[10px] shadow-lg border border-black border-opacity-10 pb-8 md:p-10 overflow-hidden"
           >
-            <div className="relative md:rounded-[10px] overflow-hidden h-[250px] w-full">
+            <div className="relative md:rounded-[10px] overflow-hidden h-[350px] w-7/8 mx-auto">
               <Image
-                className="object-cover"
+                className="w-full h-full object-cover"
                 src={`https:${card.fields.image.fields.file.url}`}
                 alt={card.fields.image.fields.description}
-                layout="fill"
+                width={500}
+                height={400}
               />
             </div>
-            <div className="md:h-min-[242px] px-5 md:px-0 flex-col ">
+            <div className="flex-grow px-5 md:px-0 ">
               {card.fields.cardContent &&
                 InfoCardContent(card.fields.cardContent)}
             </div>


### PR DESCRIPTION
# Pull Request Process

https://linear.app/ofashandfire/issue/LUS-200/info-card-image-sizing

- [ x] Image sizing should stay consistent

## Describe the changes you've made to resolve the issue

InfoCardLayout.tsx

## Add screenshots of the UI before and after your changes have been made

<!-- You should have 2 images minimum, for desktop, 4 for mobile and desktop combined -->

### Before Desktop
<img width="1374" alt="Screenshot 2024-01-25 at 2 02 11 PM" src="https://github.com/LuskinOIC/website/assets/84194997/1ae2647c-72f0-4fb9-b474-fe60100288b2">

### Before Mobile
<img width="457" alt="Screenshot 2024-01-26 at 11 27 19 AM" src="https://github.com/LuskinOIC/website/assets/84194997/2495817f-f8e0-44f9-8c6a-37e4fa6ad21e">


### After Desktop
<img width="1400" alt="Screenshot 2024-01-25 at 2 01 17 PM" src="https://github.com/LuskinOIC/website/assets/84194997/0cb5ea8d-303f-4e8e-afba-7712f5f92e3e">

### After Mobile
<img width="437" alt="Screenshot 2024-01-26 at 12 06 42 PM" src="https://github.com/LuskinOIC/website/assets/84194997/ff6f4774-13a1-4595-81cc-0233e846823e">

## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [ ] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?
