### PR TITLE
Correct blog rows cards padding

### DIFF
--- a/app/components/BlogCardsRow.tsx
+++ b/app/components/BlogCardsRow.tsx
@@ -44,7 +44,7 @@ export default function BlogCardsRow({ type, cards }: BlogCardsRowPropsType) {
           </Title1>
         </Link>
         <Link href={`/${type}`}>
-          <Title3 className="block uppercase text-[#0076AD] underline">
+          <Title3 className="block uppercase text-[#0076AD] underline md:no-underline md:hover:underline pr-5">
             See All
           </Title3>
         </Link>
@@ -52,15 +52,13 @@ export default function BlogCardsRow({ type, cards }: BlogCardsRowPropsType) {
       <div className="sm:grid grid-cols-1 gap-4 md:grid-cols-4">
         {displayedCards.map((card: BlogCardsRowType) => (
           <Link key={card.slug} href={`/${type}/${card.slug}`}>
-            <div>
-              <MinimalCard
-                cardContent={{
-                  title: card.blogCard.fields.title,
-                  cardPhoto: card.blogCard.fields.image,
-                  summary: card.blogCard.fields.subTitle || "",
-                }}
-              />
-            </div>
+            <MinimalCard
+              cardContent={{
+                title: card.blogCard.fields.title,
+                cardPhoto: card.blogCard.fields.image,
+                summary: card.blogCard.fields.subTitle || "",
+              }}
+            />
           </Link>
         ))}
       </div>

--- a/app/components/MinimalCard.tsx
+++ b/app/components/MinimalCard.tsx
@@ -15,9 +15,8 @@ const titleImageComponentStyles = {
 };
 
 const titleImageSummaryComponentStyles = {
-  image: "rounded-xl w-80 md:w-[300px] h-[280px] object-cover",
-  wrapperDiv:
-    "mx-auto md:m-4 max-w-xs md:max-w-sm flex flex-col mb-10 hover:underline",
+  image: "place-self-center rounded-xl w-80 h-[280px] object-cover",
+  wrapperDiv: "max-w-xs md:max-w-sm flex flex-col mb-10 hover:underline",
   header: "md:text-center py-4 text-xl font-bold",
   summary: "mb-4 line-clamp-4 overflow-hidden leading-tight",
 };

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -80,12 +80,12 @@ export default async function NewsArticle({
           </div>
         )}
       </section>
-      <section className="grid gap-5">
+      <section className="grid">
         {pageSections.map((section: PageSectionType) => (
           <PageSection key={section.fields.title} section={section} />
         ))}
       </section>
-      <section className="mx-auto">
+      <section className="block mx-5 md:mx-[5%]">
         <BlogCardsRow type="news" cards={news} />
       </section>
     </main>


### PR DESCRIPTION
Adjust padding for blog row


Before:
<img width="450" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/5ddd4fe8-e86a-4702-bda8-c4db267c0558">


After:
<img width="450" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/107e8d2a-c982-41ea-8c1d-1fef24d30c5e">
<img width="250" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/64bb169d-66e1-453c-b79e-a8907a16e1d2">
