### PR TITLE
Yolineb/adjust padding blog and sponsors

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -41,11 +41,9 @@ export default async function Blog() {
         <p className="px-1 pb-4">Choose a section you would like to review</p>
         <Dropdown placeHolder="News" options={dropdownOptions} />
       </div>
-      <div className="mx-5 md:mx-[5%]">
-        <BlogCardsRow type="news" cards={news} />
-        <BlogCardsRow type="events" cards={events} />
-        <BlogCardsRow type="patient-stories" cards={patientStories} />
-      </div>
+      <BlogCardsRow type="news" cards={news} />
+      <BlogCardsRow type="events" cards={events} />
+      <BlogCardsRow type="patient-stories" cards={patientStories} />
     </main>
   );
 }

--- a/app/components/BlogCardsRow.tsx
+++ b/app/components/BlogCardsRow.tsx
@@ -36,7 +36,7 @@ export default function BlogCardsRow({ type, cards }: BlogCardsRowPropsType) {
   }, [cards]);
 
   return (
-    <section id={`${type}`}>
+    <section id={`${type}`} className="block mx-5 md:mx-[5%]">
       <div className="flex flex-row justify-between mb-2 mt-8 md:mb-4">
         <Link href={`/${type}`}>
           <Title1 className="font-bold md:font-normal uppercase text-[#0076AD] md:capitalize hover:underline">

--- a/app/components/MinimalCard.tsx
+++ b/app/components/MinimalCard.tsx
@@ -16,7 +16,8 @@ const titleImageComponentStyles = {
 
 const titleImageSummaryComponentStyles = {
   image: "place-self-center rounded-xl w-80 h-[280px] object-cover",
-  wrapperDiv: "max-w-xs md:max-w-sm flex flex-col mb-10 hover:underline",
+  wrapperDiv:
+    "mx-auto max-w-xs md:max-w-sm flex flex-col mb-10 hover:underline",
   header: "md:text-center py-4 text-xl font-bold",
   summary: "mb-4 line-clamp-4 overflow-hidden leading-tight",
 };

--- a/app/components/PageSection/ColumnsLayout/SponsorshipsTwoColumn.tsx
+++ b/app/components/PageSection/ColumnsLayout/SponsorshipsTwoColumn.tsx
@@ -40,7 +40,7 @@ export default function SponsorshipsColumnLayout({
           href={s.fields.buttonUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className={`${orderClass} mx-4 my-4 h-20 w-20 md:flex md:h-auto md:w-auto`}
+          className={`${orderClass} w-20 md:flex h-auto md:w-auto md:h-[150px]  mx-4 my-4`}
         >
           <DynamicImage
             alt="sponsors"
@@ -57,7 +57,9 @@ export default function SponsorshipsColumnLayout({
   return (
     <section className={`block ${verticalPadding}`}>
       <div className={`${orderClass}`}>
-        <div className={`flex flex-col md:flex-row ${bgColor} justify-between`}>
+        <div
+          className={`flex flex-col md:flex-row ${bgColor} justify-between  items-center`}
+        >
           <div
             id="sponsor-assets"
             className=" flex flex-wrap border md:border-0 md:w-[60%]"

--- a/app/corporate-sponsorship/page.tsx
+++ b/app/corporate-sponsorship/page.tsx
@@ -12,9 +12,7 @@ export default async function CorporateSponsorship() {
       {page.pageSections.map((section: PageSectionType) => (
         <PageSection key={section.fields.title} section={section} />
       ))}
-      <section className="flex justify-center">
-        <BlogCardsRow type="news" cards={news} />
-      </section>
+      <BlogCardsRow type="news" cards={news} />
     </main>
   );
 }

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -22,10 +22,7 @@ export default async function Event({ params }: { params: { slug: string } }) {
             <PageSection key={section.fields.title} section={section} />
           ))}
       </div>
-
-      <div id="event-cards" className="grid justify-center">
-        <BlogCardsRow type="events" cards={allEvents} />
-      </div>
+      <BlogCardsRow type="events" cards={allEvents} />
     </main>
   );
 }

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -85,9 +85,7 @@ export default async function NewsArticle({
           <PageSection key={section.fields.title} section={section} />
         ))}
       </section>
-      <section className="block mx-5 md:mx-[5%]">
-        <BlogCardsRow type="news" cards={news} />
-      </section>
+      <BlogCardsRow type="news" cards={news} />
     </main>
   );
 }

--- a/app/patient-stories/[slug]/page.tsx
+++ b/app/patient-stories/[slug]/page.tsx
@@ -29,9 +29,7 @@ export default async function PatientStories({
         patient.pageSections.map((pageSection: PageSectionType) => (
           <PageSection key={pageSection.fields.title} section={pageSection} />
         ))}
-      <section className="flex justify-center">
-        <BlogCardsRow type="patient-stories" cards={patients} />
-      </section>
+      <BlogCardsRow type="patient-stories" cards={patients} />
     </main>
   );
 }


### PR DESCRIPTION
# Pull Request Process

Corrected sponsorship image sizing to be consistent even if there is only one sponsor showing in a slide
Refactored files that called BlogCardsRow for consistent padding/margins

## Add screenshots of the UI before and after your changes have been made

### Before


### After


sponsors:
<img width="768" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/e9f8f2fa-9d12-4edb-a73d-871f997a6600">

## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [ ] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?
