### PR TITLE
Adjusted Newsletter Placeholder

### DIFF
--- a/app/components/NewsletterSignup.tsx
+++ b/app/components/NewsletterSignup.tsx
@@ -49,7 +49,7 @@ export default function NewsletterSignup() {
               <input
                 type="text"
                 placeholder="Enter your email"
-                className="w-fit text-center md:text-center border border-luskin-blue rounded-[5px] pt-2 pb-3 px-3 md:px-6 placeholder:opacity-50 placeholder:text-black placeholder:text-[0.92rem] md:placeholder:text-base"
+                className="w-fit text-left md:text-center border border-luskin-blue rounded-[5px] pt-2 pb-3 px-3 md:px-6 placeholder:opacity-50 placeholder:text-black placeholder:text-[0.92rem] md:placeholder:text-base"
               />
               <button
                 className={desktopButtonClass}

--- a/app/components/NewsletterSignup.tsx
+++ b/app/components/NewsletterSignup.tsx
@@ -48,8 +48,8 @@ export default function NewsletterSignup() {
             <div className="w-fit flex justify-center mt-8 mb-12 mx-3">
               <input
                 type="text"
-                placeholder="Enter your email address"
-                className="w-fit text-left md:text-center border border-luskin-blue rounded-[5px] pt-2 pb-3 px-3 md:px-6 placeholder:opacity-50 placeholder:text-black placeholder:text-[0.92rem] md:placeholder:text-base"
+                placeholder="Enter your email"
+                className="w-fit text-center md:text-center border border-luskin-blue rounded-[5px] pt-2 pb-3 px-3 md:px-6 placeholder:opacity-50 placeholder:text-black placeholder:text-[0.92rem] md:placeholder:text-base"
               />
               <button
                 className={desktopButtonClass}


### PR DESCRIPTION
## [LUS-237 Newsletter Form Placeholder](https://linear.app/ofashandfire/issue/LUS-237/newsletter-form-placeholder)

Issue: Placeholder text was cut-off 

## How was it addressed
Changed placeholder text and aligned text so that it is centered

## Screenshots
<img width="638" alt="Screenshot 2024-02-05 at 12 05 57 PM" src="https://github.com/LuskinOIC/website/assets/111009759/b3fa70b4-2c60-4295-8b26-87273fd9c0a8">

