### PR TITLE
Aligned Mobile Footer Title

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -33,7 +33,7 @@ export default function Footer() {
         >
           <h1
             id="organization-header"
-            className="text-lg font-semibold tracking-wide text-center"
+            className="text-lg font-semibold tracking-wide text-left"
           >
             LuskinOIC Pediatric Orthopedic
           </h1>


### PR DESCRIPTION
## [LUS-243: Mobile Footer Title Alignment](https://linear.app/ofashandfire/issue/LUS-243/mobile-footer-title-alignment)

Changed Alignment of title from center to left. 

## Screenshots

<img width="381" alt="Screenshot 2024-02-06 at 1 48 40 PM" src="https://github.com/LuskinOIC/website/assets/111009759/0ec603a7-fd1a-4e02-bcc5-31d28c1ab031">


