### PR TITLE
Add hover states main navbar links

### DIFF
--- a/app/components/NabarLayout/MobileMenu.tsx
+++ b/app/components/NabarLayout/MobileMenu.tsx
@@ -35,7 +35,7 @@ function MobileMenu({
   return (
     <NavigationMenuList className="block md:hidden bg-[#0076AD]">
       {isHamburgerOpen && (
-        <ul className="text-white w-full text-sm font-semibold flex flex-col justify-center items-center pt-4 pb-0">
+        <ul className="text-white underline w-full text-sm font-semibold flex flex-col justify-center items-center pt-4 pb-0">
           <a
             href={SAVE_MY_SPOT}
             target="_blank"
@@ -50,12 +50,15 @@ function MobileMenu({
               key={index}
               className={`${item.cssClasses} w-full text-center py-2`}
             >
-              <button onClick={() => toggleMobileMenu(index)}>
+              <button
+                onClick={() => toggleMobileMenu(index)}
+                className="underline"
+              >
                 {item.label}
               </button>
 
               {mobileMenuOpenStates[index] && (
-                <ul className="bg-gray-100 text-luskin-blue w-full text-sm flex flex-col py-2">
+                <ul className="bg-gray-100 text-luskin-blue underline w-full text-sm flex flex-col py-2">
                   {item.subItems.map((subItem, subIndex) => (
                     <li
                       key={subIndex}

--- a/app/components/NabarLayout/Navbar.tsx
+++ b/app/components/NabarLayout/Navbar.tsx
@@ -75,7 +75,7 @@ export default function Navbar() {
             <div
               className={`flex flex-row justify-end h-fit transition-transform ease-out ${widgetTransformClass}`}
             >
-              <div className="hidden md:flex bg-luskin-purple px-3 py-1 font-medium text-white rounded-bl-lg hover:underline">
+              <div className="hidden md:flex bg-luskin-purple px-3 py-1 font-medium text-white rounded-bl-lg underline hover:text-slate-200">
                 <a
                   href={SAVE_MY_SPOT}
                   target="_blank"
@@ -87,7 +87,7 @@ export default function Navbar() {
               <div>
                 <ul className="hidden md:flex font-bold bg-luskin-brightBlue text-black py-1 px-3">
                   <li className="mr-4">(213) 742 - 1000</li>
-                  <li className="mr-4 hover:underline">
+                  <li className="mr-4 underline hover:text-slate-200">
                     <a
                       href={MYCHART_URL}
                       target="_blank"
@@ -96,7 +96,7 @@ export default function Navbar() {
                       MyChart
                     </a>
                   </li>
-                  <li className="mr-4 hover:underline">
+                  <li className="mr-4 underline hover:text-slate-200">
                     <a href="/espanol">Español</a>
                   </li>
                 </ul>
@@ -105,7 +105,7 @@ export default function Navbar() {
           </div>
 
           <div className="hidden md:block w-full">
-            <div className="flex justify-evenly items-center w-full">
+            <div className="flex justify-evenly items-center w-full underline hover:text-slate-200">
               <NavbarDropdown
                 id="patientCare"
                 label="Patient Care"
@@ -154,7 +154,7 @@ export default function Navbar() {
                 ]}
               />
               <Link
-                className="block text-white text-xl hover:underline"
+                className="block text-white text-xl underline hover:text-slate-200"
                 href="/ways-to-give"
               >
                 Ways to Give

--- a/app/components/NabarLayout/NavbarDropdown.tsx
+++ b/app/components/NabarLayout/NavbarDropdown.tsx
@@ -62,6 +62,7 @@ function NavbarDropDown({
         onMouseEnter={handleFocus}
         onClick={handleFocus}
         onMouseLeave={() => setHasNavigatedFromButton(true)}
+        className="underline hover:text-slate-200"
       >
         {label}
       </button>

--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -63,7 +63,7 @@ const Button = ({
     {
       bluePrimary: "bg-[#0076AD]",
       purple: "bg-[#825AA4]",
-      yellowPrimary: "bg-amber-200 text-neutral-900",
+      yellowPrimary: "bg-amber-200 text-neutral-900 hover:bg-amber-400",
       text: "p-0 underline md:px-0",
       none: "",
       blueSecondary: "bg-[#FFFFFF] text-[#0076AD] border-2 border-[#0076AD]",


### PR DESCRIPTION
Per Jason's request, add underlines + hover states to main navbar links


<img width="500" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/5807eb11-d996-42e7-b6c4-04f79b9b9342">

<img width="250" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/7d1608c7-f261-4648-88ba-c0b8c4a931e5">

