### PR TITLE
Adjust carousel width sizing

### DIFF
--- a/app/components/ImagesLayoutComponents/styles.tsx
+++ b/app/components/ImagesLayoutComponents/styles.tsx
@@ -1,7 +1,7 @@
 export const styles = {
   container:
     "flex flex-col w-full h-[260px] md:block md:relative md:min-h-[560px] md:overflow-hidden mb-4 md:mb-10 md:text-left",
-  image: "h-full",
+  image: "w-full h-full md:h-auto",
   btn: "md:w-auto text-center my-2 md:mx-0",
   overlayDesktop:
     "md:absolute md:left-0 md:top-[25%] md:left-[7%] md:max-w-[500px] md:transform bg-white md:bg-opacity-75 md:rounded md:p-6",


### PR DESCRIPTION
This is a quick fix for adjusting carousel image sizing

### Before
<img width="400" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/24151772-4c7f-4605-9f54-ebbad62f4792">

<img width="250" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/95c87a8c-903d-4e36-9096-22d912af8edf">

### After
<img width="400" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/67c9c094-1d1b-47d8-ab91-0ee0c94a22fd">

<img width="250" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/0e262262-84f8-4374-80be-ec4c63bd84b2">
