### PR TITLE
Conditional Rendering Logic - leadership

### DIFF
--- a/app/leadership/[slug]/page.tsx
+++ b/app/leadership/[slug]/page.tsx
@@ -14,7 +14,7 @@ export default async function LeadershipMember({
   const member = await getLeadershipBioBySlug(params.slug);
   return (
     <div>
-      <TwoColumnLayout section={member.topSection} />
+      {member.topSection && <TwoColumnLayout section={member.topSection} />}
     </div>
   );
 }


### PR DESCRIPTION
Added conditional rendering logic, but brings up question

Do we want members to be under a /members/[slug] or /leadership/[slug]? Will check in once styles clean up is through, I believe this is related to a general contentful clean up that is not a release blocker. 