### PR TITLE
Correct urgent care check for specialties

### DIFF
--- a/app/specialties/SpecialtyComponents/SpecialtyGridLayout.tsx
+++ b/app/specialties/SpecialtyComponents/SpecialtyGridLayout.tsx
@@ -21,7 +21,7 @@ export default function SpecialtyGridLayout({
         )}
         {specialties.map((specialty) => {
           const specialtyName = specialty.fields.name;
-          return specialtyName == "Pediatric Orthopedic Urgent Care" &&
+          return specialtyName.toLowerCase().includes("urgent care") &&
             !showingSearchResults ? ( // Expand the Urgent Care Card if not showing search results
             <div className="order-first" key={specialtyName}>
               <UrgentCareCard specialty={specialty} />


### PR DESCRIPTION
Corrects Urgent Care card conditional in case spelling changes - still relies on 'urgent care' to exist in title