### PR TITLE
Yolineb/carousel mobile

### DIFF
--- a/app/components/ImagesLayoutComponents/CarouselImageOverlay.tsx
+++ b/app/components/ImagesLayoutComponents/CarouselImageOverlay.tsx
@@ -42,6 +42,19 @@ const OverlayComponent = ({
 export default function CarouselImageSlider({
   section,
 }: CarouselImageLayoutProps) {
+  const alignmentClass = (alignment: string) => {
+    switch (alignment) {
+      case "left":
+        return "md:left-1/4";
+      case "center":
+        return "md:left-1/2";
+      case "right":
+        return "md:left-2/3";
+      default:
+        return "md:left-1/4";
+    }
+  };
+
   return (
     <section className="py-4">
       <Slider
@@ -57,7 +70,11 @@ export default function CarouselImageSlider({
                   className={styles.image}
                 />
                 {(slide.fields.overlayTitle || slide.fields.overlayButton) && (
-                  <div className={styles.overlayDesktop}>
+                  <div
+                    className={`${styles.overlayDesktop} ${alignmentClass(
+                      slide.fields.overlayAlignment,
+                    )}`}
+                  >
                     <OverlayComponent
                       overlayTitle={slide.fields.overlayTitle}
                       overlayButton={slide.fields.overlayButton}

--- a/app/components/ImagesLayoutComponents/CarouselImageOverlay.tsx
+++ b/app/components/ImagesLayoutComponents/CarouselImageOverlay.tsx
@@ -43,27 +43,29 @@ export default function CarouselImageSlider({
   section,
 }: CarouselImageLayoutProps) {
   return (
-    <section>
+    <section className="py-4">
       <Slider
         slides={
           section.map((slide, i) => (
-            <div key={i} className={styles.container}>
-              <Image
-                src={slide.fields.image.fields.file.url}
-                alt={slide.fields.image.fields.file.fileName}
-                width={slide.fields.image.fields.file.details.image.width}
-                height={slide.fields.image.fields.file.details.image.height}
-                className={styles.image}
-              />
-              {(slide.fields.overlayTitle || slide.fields.overlayButton) && (
-                <div className={styles.overlayDesktop}>
-                  <OverlayComponent
-                    overlayTitle={slide.fields.overlayTitle}
-                    overlayButton={slide.fields.overlayButton}
-                    btnStyle={styles.btn}
-                  />
-                </div>
-              )}
+            <div key={i} className="flex items-center h-full">
+              <div className={styles.container}>
+                <Image
+                  src={slide.fields.image.fields.file.url}
+                  alt={slide.fields.image.fields.file.fileName}
+                  width={slide.fields.image.fields.file.details.image.width}
+                  height={slide.fields.image.fields.file.details.image.height}
+                  className={styles.image}
+                />
+                {(slide.fields.overlayTitle || slide.fields.overlayButton) && (
+                  <div className={styles.overlayDesktop}>
+                    <OverlayComponent
+                      overlayTitle={slide.fields.overlayTitle}
+                      overlayButton={slide.fields.overlayButton}
+                      btnStyle={styles.btn}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           )) as any
         }

--- a/app/components/ImagesLayoutComponents/styles.tsx
+++ b/app/components/ImagesLayoutComponents/styles.tsx
@@ -4,6 +4,6 @@ export const styles = {
   image: "w-full h-auto aspect-ratio",
   btn: "md:w-auto text-center my-2 md:mx-0",
   overlayDesktop:
-    "md:absolute md:left-0 md:top-[25%] md:left-[7%] md:max-w-[500px] md:transform bg-white md:bg-opacity-75 md:rounded md:p-6",
+    "md:absolute md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:max-w-[500px] bg-white md:bg-opacity-75 md:rounded md:p-6",
   title: "font-normal lg:text-[48px] leading-snug",
 };

--- a/app/components/ImagesLayoutComponents/styles.tsx
+++ b/app/components/ImagesLayoutComponents/styles.tsx
@@ -1,7 +1,7 @@
 export const styles = {
   container:
-    "flex flex-col w-full h-[260px] md:block md:relative md:min-h-[560px] md:overflow-hidden mb-4 md:mb-10 md:text-left",
-  image: "w-full h-full md:h-auto",
+    "flex flex-col w-full md:block md:relative md:overflow-hidden md:text-left",
+  image: "w-full h-auto aspect-ratio",
   btn: "md:w-auto text-center my-2 md:mx-0",
   overlayDesktop:
     "md:absolute md:left-0 md:top-[25%] md:left-[7%] md:max-w-[500px] md:transform bg-white md:bg-opacity-75 md:rounded md:p-6",

--- a/app/components/Slider.tsx
+++ b/app/components/Slider.tsx
@@ -109,16 +109,16 @@ const Slider: React.FC<SliderProps> = ({ slides }) => {
           transitionEnabled
             ? "transition-transform duration-500 ease-in-out"
             : ""
-        } h-full`}
+        }`}
         style={{ transform: `translateX(${slideOffset}%)` }}
       >
         {wrappedSlides.map((slide: any, index) => (
-          <div key={index} className="mb-3 w-full flex-shrink-0 text-center">
+          <div key={index} className="w-full flex-shrink-0 text-center">
             {slide}
           </div>
         ))}
       </div>
-      <div className="absolute bottom-0 left-0 right-0 mb-2 flex items-center justify-center">
+      <div className="flex h-full items-center justify-center py-2">
         <button aria-label="left arrow" onClick={prevSlide}>
           <LeftArrow />
         </button>

--- a/app/constants/types.ts
+++ b/app/constants/types.ts
@@ -60,7 +60,7 @@ export type CarouselSlideType = {
   fields: {
     image: ImageType;
     overlayTitle?: string;
-    overlayAlignment?: string;
+    overlayAlignment: string;
     overlayButton?: ButtonType;
   };
 };


### PR DESCRIPTION
Correct carousel sizing for mobile - has to stay at a small height size to maintain aspect ratio

Added overlay alignment option for the luskin team

### Before
<img width="450" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/760e08c0-b255-4373-923d-b0e87079faef">


<img width="250" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/e8f60f75-4374-4e72-a74f-63efd404ae40">


### After

<img width="450" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/9b2348fc-cd4d-4a25-ad27-b75daa6afea5">
<img width="450" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/fb8c426f-1faf-4da2-b734-7463eef64bc3">
<img width="250" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/6bd1d07f-b023-47ca-af9c-2b0f19ead435">

