### PR TITLE
Correct section padding, refactor mobile overlay

### DIFF
--- a/app/components/ImagesLayoutComponents/CarouselImageOverlay.tsx
+++ b/app/components/ImagesLayoutComponents/CarouselImageOverlay.tsx
@@ -45,18 +45,18 @@ export default function CarouselImageSlider({
   const alignmentClass = (alignment: string) => {
     switch (alignment) {
       case "left":
-        return "md:left-1/4";
+        return "left-1/2 md:left-1/4";
       case "center":
-        return "md:left-1/2";
+        return "left-1/2 md:left-1/2";
       case "right":
-        return "md:left-2/3";
+        return "left-1/2 md:left-2/3";
       default:
-        return "md:left-1/4";
+        return "left-1/2 md:left-1/4";
     }
   };
 
   return (
-    <section className="py-4">
+    <section>
       <Slider
         slides={
           section.map((slide, i) => (

--- a/app/components/ImagesLayoutComponents/styles.tsx
+++ b/app/components/ImagesLayoutComponents/styles.tsx
@@ -1,9 +1,8 @@
 export const styles = {
-  container:
-    "flex flex-col w-full md:block md:relative md:overflow-hidden md:text-left",
+  container: "relative flex flex-col w-full overflow-hidden md:text-left",
   image: "w-full h-auto aspect-ratio",
-  btn: "md:w-auto text-center my-2 md:mx-0",
+  btn: "h-6 md:h-auto text-[10px] md:text-base md:w-auto text-center md:my-2 md:mx-0",
   overlayDesktop:
-    "md:absolute md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:max-w-[500px] bg-white md:bg-opacity-75 md:rounded md:p-6",
-  title: "font-normal lg:text-[48px] leading-snug",
+    "absolute top-1/2 -translate-x-1/2 -translate-y-1/2 w-auto md:max-w-[500px] bg-white bg-opacity-75 rounded p-6",
+  title: "text-[16px] lg:text-[48px] leading-snug",
 };


### PR DESCRIPTION
Correct carousel section padding

Refactor mobile overlay so that it goes on top of the picture instead of below. This keeps a consistent container for the carousel slides

### Before
<img width="599" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/b28d6092-2e30-4898-8e90-c624109bf9c6">
<img width="250" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/dcb153aa-5c0d-4e58-b415-774f3cf67eee">


### After
<img width="500" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/a329cb11-0388-4237-b6b9-84bdf6f7ded0">

<img width="250" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/2b13fbf8-6127-47b6-8f2d-de2b66bcf62d">

