### PR TITLE
Remove redundant specialty pages.

### DIFF
--- a/app/medical-professionals/specialties/[slug]/page.tsx
+++ b/app/medical-professionals/specialties/[slug]/page.tsx
@@ -2,7 +2,11 @@ import Page from "@/app/components/Page";
 import { getSpecialties, getSpecialtyBySlug } from "@/app/utils/contentful";
 
 export async function generateStaticParams() {
-  const specialties = await getSpecialties();
+  let specialties = await getSpecialties();
+  specialties = specialties.filter(
+    (specialty) => specialty.fields.medicalProfessionalPage,
+  );
+
   return specialties.map((specialty) => ({
     slug: specialty.fields.slug,
   }));
@@ -14,10 +18,6 @@ export default async function Specialty({
   params: { slug: string };
 }) {
   const specialty = await getSpecialtyBySlug(params.slug);
-
-  if (!specialty || !specialty.fields.medicalProfessionalPage) {
-    return <h1>Add Page Sections</h1>;
-  }
 
   return <Page page={specialty.fields.medicalProfessionalPage.fields} />;
 }

--- a/app/patient-care/specialties/[slug]/page.tsx
+++ b/app/patient-care/specialties/[slug]/page.tsx
@@ -3,10 +3,10 @@ import { SEO_DEFAULTS } from "@/app/constants/seo";
 import { getSpecialties, getSpecialtyBySlug } from "@/app/utils/contentful";
 import type { Metadata } from "next";
 import { PagePropsType } from "@/app/constants/types";
-import { redirect } from "next/navigation";
 
 export async function generateStaticParams() {
-  const specialties = await getSpecialties();
+  let specialties = await getSpecialties();
+  specialties = specialties.filter((specialty) => specialty.fields.patientPage);
   return specialties.map((specialty) => ({
     slug: specialty.fields.slug,
   }));
@@ -32,10 +32,6 @@ export default async function Specialty({
   params: { slug: string };
 }) {
   const specialty = await getSpecialtyBySlug(params.slug);
-
-  if (!specialty?.fields?.patientPage) {
-    return redirect("/specialties");
-  }
 
   return <Page page={specialty.fields.patientPage.fields} />;
 }

--- a/app/sitemap.json
+++ b/app/sitemap.json
@@ -1,2005 +1,1945 @@
 [
   {
     "url": "https://luskinoic.org/_not-found/",
-    "lastModified": "2024-03-11T22:52:32.148Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/about/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.7
   },
   {
     "url": "https://luskinoic.org/ambulatory-surgery-center/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/blog/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/Abnormal-Muscle-Tone/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/Accessory-Navicular/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/Achilles-Tendon-Injury/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/achilles-tenotomy/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/achondroplasia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/aneurysmal-bone-cyst/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/ankle-sprain/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/anterior-cruciate-ligament-acl-sprain-or-tear/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/anterior-spinal-fusion/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/arthrogryposis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/athetosis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/bankart-repair/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/bone-cancer/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/bone-tumors/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/boots-and-bar/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/bowed-legs/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/brachydactyly/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/cast-care/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/cerebral-palsy/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/cervical-spine-surgery/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/chondroblastoma/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/chorea/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/cleft-lip/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/cleft-palate/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/clubfoot/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/coagulation-disorder/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/congenital-coxa-vara/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/congenital-limb-disorders/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/congenital-muscular-torticollis-and-torticollis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/congenital-scoliosis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/connective-tissue-disorders/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/cyst/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/developmental-dysplasia-of-the-hip/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/diastrophic-dysplasia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/diplegia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/discoid-meniscus/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/disproportionate-dwarfism/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/dystonia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/ehlers-danlos-syndrome-eds/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/elbow-fractures/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/enchondroma/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/ewing-sarcoma/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/femoroacetabular-impingement/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/flexible-flatfeet/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/fracture/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/giant-cell-tumor/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/giant-cell-tumors/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/growing-rods-magec/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/gymnast-wrist/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/hand-trauma/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/hemiplegia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/hemophilia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/hip-disorders/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/hip-fracture/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/hip-impingement/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/hypertonia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/hypochondroplasia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/hypotonia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/idiopathic-isolated-clubfoot/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/idiopathic-scoliosis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/iliotibial-it-band-syndrome/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/interbody-spinal-fusion/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/involuntary-movements/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/juvenile-idiopathic-arthritis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/knock-knees/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/leg-length-discrepancy/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/leg-lengthening/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/legg-calve-perthes-disease/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/ligament-injuries/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/limb-salvage/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/little-league-elbow/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/little-league-shoulder/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/longitudinal-deficiency/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/lumbar-spine-surgery/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/marfan-syndrome/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/medial-epicondylitis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/meniscal-tear/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/metatarsus-adductus-also-called-metatarsus-varus/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/monoplegia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/monostotic-fibrous-dysplasia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/muscular-dystrophy/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/neurofibromatosis-nf/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/non-isolated-clubfoot/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/non-ossifying-fibroma-nof/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/occupational-therapy/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/orthopedic-rehabilitation/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/osgood-schlatter-disease/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/osteochondritis-dissecans/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/osteochondroma/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/osteogenesis-imperfecta/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/osteoid-osteoma/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/osteosarcoma/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/patella-dislocation/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/patellar-tendonitis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/patellofemoral-syndrome/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/pavlik-harness/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/physical-therapy/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/plantar-fasciitis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/polydactyly/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/polyostotic-fibrous-dysplasia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/ponseti-method/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/posterior-spinal-fusion/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/proportionate-dwarfism/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/pseudoachondroplasia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/quadriplegia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/rheumatoid-arthritis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/rigidity/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/rocker-bottom-foot-vertical-talus/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/scheuermanns-kyphosis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/scleroderma/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/scoliosis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/scoliosis-and-kyphosis-bracing/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/scoliosis-surgery/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/severs-disease/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/shoulder-dislocation/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/sickle-cell-disease-and-anemia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/skeletal-dysplasia-dwarfism/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/slipped-capital-femoral-epiphysis-scfe/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/snapping-hip/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/soft-tissue-tumors/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/spasticity/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/spica-cast/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/spinal-fusion-anterior-posterior-interbody/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/spondyloepiphyseal-dysplasia-congenita-sedc/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/spondylolysis-and-spondylolisthesis/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/sports-medicine/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/supracondylar-fracture/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/symbrachydactyly/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/syndactyly/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/systemic-lupus-erythematosus-sle-or-lupus/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/telemedicine/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/toe-deformities/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/toe-walking/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/total-body-involvement-cerebral-palsy/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/transverse-deficiency/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/triplegia/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/turner-syndrome/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/unicameral-bone-cyst-ubc/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/vertical-expandable-prosthetic-titanium-rib-procedure-veptr/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/wrist-fractures/learn-more/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/conditions/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/corporate-partnership/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/espanol/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/events/2023-wine-glass-experience/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/events/cerebral-palsy-summer-camp-2023/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/events/dtla-youth-soccer-club-partnership/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/events/stand-for-kids-gala-2024/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/events/swing-for-kids/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/events/the-2023-swing-for-kids-was-a-succes/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/events/toys-and-joy/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/events/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/example-custom-page/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/index/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/international-childrens-program/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/anthony-scaduto-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/brad-feld/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/celene-chan-andrews/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/christine-chris-wright-roper/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/craig-ehrlich/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/david-luskin/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/elisa-rodriguez/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/harold-davidson/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/hilary-a-norton/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/james-arnold-jr/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/jamie-wells-mha-bsn-rn/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/jason-silletti/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/joan-prestine/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/joel-bernstein-vice-chair/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/kerbanu-pudumjee/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/lannie-tonnu/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/mark-zytko/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/maureen-stockton/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/michael-dal-bello/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/michael-p-sullivan/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/miki-jordan/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/nanci-rossi/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/ophelia-portillo/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/peverley-j-hukill-phd/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/philip-han/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/rachel-davis/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/richard-e-giss/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/sarah-jonovic/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/steven-valentine-chair/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/toni-steele/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/troy-jenkins/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/william-wynperle/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/leadership/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
-    "url": "https://luskinoic.org/medical-professionals/specialties/arthrogryposis/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.8
-  },
-  {
-    "url": "https://luskinoic.org/medical-professionals/specialties/bone-tumors/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.8
-  },
-  {
     "url": "https://luskinoic.org/medical-professionals/specialties/cerebral-palsy/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/medical-professionals/specialties/clubfoot/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.8
-  },
-  {
-    "url": "https://luskinoic.org/medical-professionals/specialties/congenital-limb-disorder/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.8
-  },
-  {
-    "url": "https://luskinoic.org/medical-professionals/specialties/connective-tissue-disorders/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.8
-  },
-  {
-    "url": "https://luskinoic.org/medical-professionals/specialties/craniofacial-cleft-palate/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/medical-professionals/specialties/fractures/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.8
-  },
-  {
-    "url": "https://luskinoic.org/medical-professionals/specialties/hand-trauma/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/medical-professionals/specialties/hemophilia/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.8
-  },
-  {
-    "url": "https://luskinoic.org/medical-professionals/specialties/hip-disorders/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.8
-  },
-  {
-    "url": "https://luskinoic.org/medical-professionals/specialties/orthopedic-rehabilitation/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/medical-professionals/specialties/scoliosis/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.8
-  },
-  {
-    "url": "https://luskinoic.org/medical-professionals/specialties/skeletal-dysplasia-dwarfism/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/medical-professionals/specialties/sports-medicine/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/medical-professionals/specialties/urgent-care/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/medical-professionals/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/member/anthony-scaduto-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/brad-feld/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/celene-chan-andrews/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/christine-chris-wright-roper/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/craig-ehrlich/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/david-luskin/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/elisa-rodriguez/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/harold-davidson/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/hilary-a-norton/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/james-arnold-jr/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/jamie-wells-mha-bsn-rn/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/jason-silletti/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/joan-prestine/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/joel-bernstein-vice-chair/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/kerbanu-pudumjee/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/lannie-tonnu/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/mark-zytko/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/maureen-stockton/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/michael-dal-bello/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/michael-p-sullivan/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/miki-jordan/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/nanci-rossi/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/ophelia-portillo/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/peverley-j-hukill-phd/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/philip-han/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/rachel-davis/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/richard-e-giss/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/sarah-jonovic/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/steven-valentine-chair/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/toni-steele/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/troy-jenkins/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/member/william-wynperle/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/2023-donor-report/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/2023-volunteer-award-winners/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/5-important-facts-about-treating-clubfoot-with-the-ponseti-method/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.7
   },
   {
     "url": "https://luskinoic.org/news/5-ways-to-keep-your-bones-healthy/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/common-kids-sports-related-injuries/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/four-tips-to-get-you-through-the-clubfoot-brace-years/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/luskinoic-proudly-celebrates-dr-nicholas-m-bernthal-as-chair-of-the-ucla/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/luskinoic-top-23-of-2023/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/orthopaedic-hospital-research-center-ucla-westwood/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/trust-luskinoic-experts-to-diagnose-treat-and-manage-your-childs-scoliosis/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/ucla-or-luskinoic-center-for-cerebral-palsy-margaret-jones-professional/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/ucla-wbb-luskinoic-night/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/welcome-providers-2023/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/news/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/arthrogryposis/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/bone-tumors/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/cerebral-palsy/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/clubfoot/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/congenital-limb-disorder/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/connective-tissue-disorders/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/craniofacial-cleft-palate/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/fractures/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/hand-trauma/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/hemophilia/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/hip-disorders/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/orthopedic-rehabilitation/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/scoliosis/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/skeletal-dysplasia-dwarfism/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/sports-medicine/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/specialties/urgent-care/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-care/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.8
   },
   {
     "url": "https://luskinoic.org/patient-stories/adelle/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/ana/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/arturo/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/asad/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/bibiana/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/braun/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/charlie/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/christian/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/efrain/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/example-patient/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/golden/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/gordon/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/greg/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/isabella/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/ivanna/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/ivonne/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/jenna/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/jessica/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/khedhar/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/kosta/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/leah/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/lizeth/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/octavio/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/patient-allison/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/patient-ramses/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/scarlett/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/tarra/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/patient-stories/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/Annie-Tashjian-PNP/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/amanda-honsvall-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/anthony-scaduto-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/antonio-morales/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/calvin-duffaut-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/cassidy-forsyth/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/christiana-abram-np/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
-    "changeFrequency": "monthly",
-    "priority": 0.4
-  },
-  {
-    "url": "https://luskinoic.org/physicians/christine-caron/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/christopher-chan-np-c/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/donald-hoechlin/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/doris-quon-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/emily-miller/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/genesis-fuerte-np/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/james-luck-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/joan-wright-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/joshua-goldman-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/justin-barad-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/libby-wilson/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/maebel-tan/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/mauricio-silva-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/neil-jones-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/nicholas-bernthal-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/patricia-mckeever-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/phong-truong/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/rachel-thompson-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/richard-bowen-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/sean-warnock-fnp-c/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/shadab-moini-pa/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/timothy-schaub-md/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/victoria-kang-do/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/physicians/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/specialties/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/style-guide/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.4
   },
   {
     "url": "https://luskinoic.org/ways-to-give/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 0.5
   },
   {
     "url": "https://luskinoic.org/",
-    "lastModified": "2024-03-11T22:52:32.149Z",
+    "lastModified": "2024-03-20T19:33:07.562Z",
     "changeFrequency": "monthly",
     "priority": 1
   }


### PR DESCRIPTION
# Pull Request Process

## Copy and Paste / Write ticket description

This PR addresses the issue of unwanted specialty pages being generated without an associated page class. The fix was implemented in the Next.js `generateStaticParams` method by filtering out specialties that do not have a corresponding patient page, ensuring only valid pages are generated.

## Describe the changes you've made to resolve the issue

Modified the `generateStaticParams` function in the Next.js configuration to filter out any specialty that lacks an associated `patientPage`. The change ensures that only specialties with a valid `patientPage` are included in the static generation process.

```javascript
export async function generateStaticParams() {
  let specialties = await getSpecialties();
  specialties = specialties.filter((specialty) => specialty.fields.patientPage);
  return specialties.map((specialty) => ({
    slug: specialty.fields.slug,
  }));
}
```

## Add screenshots of the UI before and after your changes have been made

N/A

## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [X] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [X] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [X] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [X] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [X] If you don't feel super confident in your review, did you assign someone more senior to double check?
