### PR TITLE
Blog Hover & Rich Text Correction

### DIFF
--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -6,7 +6,7 @@ import renderRichTextToReactComponent from "../utils/rich-text";
 import { cn } from "@/lib/utils";
 
 const style = {
-  image: "place-self-center rounded-xl w-80 object-cover hover:opacity-80",
+  image: "place-self-center rounded-xl w-80 object-cover",
   wrapperDiv: "mx-auto max-w-xs md:max-w-sm flex flex-col gap-y-2 mb-10",
   header: "line-clamp-3 text-xl font-bold text-center leading-normal pt-2",
   summary: "line-clamp-4 overflow-hidden leading-tight",
@@ -48,7 +48,7 @@ export default function BlogCard({
         height={cardPhotoWidth}
         className={`${style.image} ${
           type === "patient-stories" ? "h-auto md:h-full" : "h-[280px]"
-        }`}
+        } ${isHovered ? "opacity-80" : ""}`}
       />
       <h3 className={`${style.header} ${hoverClass}`}>{title}</h3>
       {summary && type === "patient-stories" ? (

--- a/app/components/ui/Typography/Title.tsx
+++ b/app/components/ui/Typography/Title.tsx
@@ -37,7 +37,7 @@ export const Title1 = ({ id, children, className = "" }: TitleProps) => {
 
 export const Title2 = ({ children, className = "" }: TitleProps) => {
   const classes = cn(
-    "text-xl md:text-2xl font-arial leading-[36px] py-2",
+    "text-xl md:text-2xl font-arial leading-[36px] md:leading-[45px] py-2",
     className,
   );
   return <h1 className={classes}>{children}</h1>;

--- a/app/utils/rich-text.tsx
+++ b/app/utils/rich-text.tsx
@@ -47,7 +47,7 @@ export default function renderRichTextToReactComponent(
         <Title2 className="font-bold pb-5">{children}</Title2>
       ),
       [BLOCKS.HEADING_3]: (node: any, children: React.ReactNode) => (
-        <Title2 className="font-semibold pb-5">{children}</Title2>
+        <Title2 className="pb-5">{children}</Title2>
       ),
       [BLOCKS.HEADING_4]: (node: any, children: React.ReactNode) => (
         <Title3 className="font-medium">{children}</Title3>


### PR DESCRIPTION
# Pull Request Process

This ticket fixes issue #234 

Additionally, it addresses the rich text header option so that H3 is not automatically bold - if the user wants to have H3 titles bold, they can click the 'bold' option in the editor. 

## Describe the changes you've made to resolve the issue

Blog Card hover component

Rich text util component

## Add screenshots of the UI before and after your changes have been made


### Before

<img width="500" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/b3cf8684-efc9-4033-8c56-4b22625c885b">


### After

<img width="500" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/04635bc4-70c9-4f6a-909e-dfe753701f7a">


## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [ ] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?
