### PR TITLE
Landing Page SEO Meta tag

### DIFF
--- a/app/constants/seo.ts
+++ b/app/constants/seo.ts
@@ -1,6 +1,6 @@
 export const SEO_DEFAULTS = {
   TITLE:
-    "Pediatric Orthopedic Doctor - Luskin Orthopaedic Institute for Children",
+    "Pediatric Orthopaedic Doctor - Luskin Orthopaedic Institute for Children",
   DESCRIPTION:
     "Luskin Orthopaedic Institute for Children provides the highest levels of specialized care in pediatric orthopedics. Your child will receive exceptional care & treatment for their pediatric orthopedic needs.",
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,19 @@
+import type { Metadata } from "next";
 import { getPageByType } from "@/app/utils/contentful";
 import { PAGE_TYPES } from "@/app/constants/entries";
 import Page from "@/app/components/Page";
+import { SEO_DEFAULTS } from "@/app/constants/seo";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const landingPage = await getPageByType(PAGE_TYPES.LANDING_PAGE);
+  const seoMetaTagFields = landingPage.seoMetaTagFields;
+
+  return {
+    title: seoMetaTagFields?.fields?.title || SEO_DEFAULTS.TITLE,
+    description:
+      seoMetaTagFields?.fields?.description || SEO_DEFAULTS.DESCRIPTION,
+  };
+}
 
 // This is the root page to the website.
 export default async function Home() {


### PR DESCRIPTION
# Pull Request Process

This was not an explicit ticket but was mentioned earlier - any mention of Orthopedic should be Orthopaedic. In this case, it was Landing page's default SEO meta data tag. 

This PR:

-Updates the spelling
-Brings in the generateMetadata function to the landing page, so that the the meta data entries from Contentful will show. 

## Describe the changes you've made to resolve the issue

Using a similar set up from the patient care page, app/page.tsx now generates the Metadata, explicitly calling Landing Page Type. 

## Add screenshots of the UI before and after your changes have been made


### Before
<img width="500" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/0d4f5040-f28f-4d16-9824-7b70815b7633">


### After

<img width="500" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/22eb74b2-7d0a-4ea7-bfeb-6c81d119eb84">


## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [ ] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?
