### PR TITLE
added field attribute to getNavigationBar function

### DIFF
--- a/app/utils/contentful.ts
+++ b/app/utils/contentful.ts
@@ -239,6 +239,7 @@ export async function getPages(): Promise<PageType[]> {
 export async function getNavigationBar(): Promise<NavigationBarType> {
   const entry = await client.getEntries({
     content_type: "navigationBar",
+    "fields.type": "Header",
     include: 2,
     locale: "en-US",
   });


### PR DESCRIPTION
# Pull Request Process

## Copy and Paste / Write ticket description

We've decided to use the Navigation Bar content model to produce a Footer Contentful component. Currently, no attribute is on the Navigation Bar content model to determine if the content will be specific to the Nav bar or Footer.

## Describe the changes you've made to resolve the issue

Added a field attribute "Type" to the getNavigationBar function to determine if content is specific to Nav bar or Footer. Changes made to file: `apps/utils/contentful.ts`

## Add screenshots of the UI before and after your changes have been made

No changes made to UI

## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [x] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [x] If you don't feel super confident in your review, did you assign someone more senior to double check?
