### PR TITLE
Fix hero banner alignment on tablet

### DIFF
--- a/app/components/ImagesLayoutComponents/styles.tsx
+++ b/app/components/ImagesLayoutComponents/styles.tsx
@@ -4,6 +4,6 @@ export const styles = {
   image: "w-full h-auto aspect-ratio",
   btn: "h-6 md:h-auto text-[10px] md:text-base md:w-auto text-center md:my-2 md:mx-0",
   overlayDesktop:
-    "absolute top-1/2 -translate-x-1/2 -translate-y-1/2 w-auto md:max-w-[500px] bg-white bg-opacity-75 rounded p-6",
+    "absolute top-1/2 md:-translate-x-[60%] lg:-translate-x-[50%] -translate-y-1/2 w-1/3 text-left lg:w-auto lg:max-w-[500px] bg-white bg-opacity-75 rounded p-6",
   title: "text-[16px] lg:text-[48px] leading-snug",
 };


### PR DESCRIPTION
Fix for hero banner alignment on tablet.

On iPad
<img width="970" alt="Screenshot 2024-05-06 at 1 29 40 PM" src="https://github.com/LuskinOIC/website/assets/73029335/3b8c350f-041e-409b-9475-38ff65bc4893">
