### PR TITLE
PageSections in Providers Page

### DIFF
--- a/app/providers/page.tsx
+++ b/app/providers/page.tsx
@@ -5,9 +5,12 @@ import { getPageByType } from "@/app/utils/contentful";
 
 // LOCAL COMPONENTS
 import { getPhysicians } from "@/app/utils/contentful";
-import { PageSectionContainer } from "@/app/components/PageSection/PageSection";
+import PageSection, {
+  PageSectionContainer,
+} from "@/app/components/PageSection/PageSection";
 // TYPES
 import {
+  PageSectionType,
   PageType,
   PhysicianBioType,
   PhysicianPageSectionType,
@@ -29,8 +32,13 @@ export default async function Physicians() {
     PAGE_TYPES.PHYSICIAN_LIST_PAGE,
     4,
   )) as unknown as PageType;
-  const sortedPhysicians: PhysicianPageSectionType[] =
-    page.pageSections as unknown as PhysicianPageSectionType[];
+  const sortedPhysicians: PhysicianPageSectionType[] = (
+    page.pageSections as unknown as PhysicianPageSectionType[]
+  ).slice(0, 3);
+
+  const contentPageSections = (
+    page.pageSections as unknown as PhysicianPageSectionType[]
+  ).slice(3);
 
   return (
     <PageSectionContainer>
@@ -38,6 +46,9 @@ export default async function Physicians() {
         physicians={physicians}
         sortedPhysicians={sortedPhysicians}
       />
+      {contentPageSections.map((pageSection: PageSectionType) => (
+        <PageSection key={pageSection.fields.title} section={pageSection} />
+      ))}
     </PageSectionContainer>
   );
 }


### PR DESCRIPTION
# Pull Request Process

Add logic for non provider related pageSections to render

## Describe the changes you've made to resolve the issue

This is a temp fix - we will take the first three page Sections for sorted provider, and the rest of the page sections will render at the bottom of the page. 

this allows us to show the index cards requested by the luskin team

## Add screenshots of the UI before and after your changes have been made

<!-- You should have 2 images minimum, for desktop, 4 for mobile and desktop combined -->

### Before
n/a, build was breaking

### After
<img width="500" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/a8d7a003-b522-4cfa-8435-bda6139e17be">

<img width="250" alt="image" src="https://github.com/LuskinOIC/website/assets/92892101/c2de6128-5b62-421f-9839-534d2c41eb07">



## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [ ] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?
