### PR TITLE
News/Insights img src logic + news/events dates correction

### DIFF
--- a/app/blog/components/PostComponent.tsx
+++ b/app/blog/components/PostComponent.tsx
@@ -29,6 +29,8 @@ const PostComponent = ({ postData }: PostComponentProps) => {
   const { url, details, fileName } = mainImage.fields.file;
   const formattedDate = formatDate(date);
 
+  const shouldDisplayMainImage =
+    pageSections.length > 0 && pageSections[0].fields.type !== "Images Layout";
   return (
     <>
       <PageSectionContainer showTopMargin={true}>
@@ -46,17 +48,19 @@ const PostComponent = ({ postData }: PostComponentProps) => {
           </div>
         </div>
       </PageSectionContainer>
-      <PageSectionContainer showTopPadding={true} showBottomPadding={true}>
-        <Image
-          className={styles.postImage}
-          src={url}
-          alt={fileName}
-          width={details.image.width}
-          height={details.image.height}
-        />
-      </PageSectionContainer>
+      {shouldDisplayMainImage && (
+        <PageSectionContainer showTopPadding={true} showBottomPadding={true}>
+          <Image
+            className={styles.postImage}
+            src={url}
+            alt={fileName}
+            width={details.image.width}
+            height={details.image.height}
+          />
+        </PageSectionContainer>
+      )}
 
-      {pageSections.map((section: PageSectionType, i: string) => (
+      {pageSections.map((section: PageSectionType, i: number) => (
         <div
           key={i}
           className={`${

--- a/app/blog/components/mergeEventsNews.tsx
+++ b/app/blog/components/mergeEventsNews.tsx
@@ -5,7 +5,7 @@ export default function mergeAndSortArrays(array1: any, array2: any) {
     const dateA = new Date(a.date || a.eventDate).getTime();
     const dateB = new Date(b.date || b.eventDate).getTime();
 
-    return dateA - dateB;
+    return dateB - dateA;
   });
 
   return combinedArray;

--- a/app/constants/types.ts
+++ b/app/constants/types.ts
@@ -502,7 +502,7 @@ export type BlogPostType = {
     eventDate?: string;
     writtenBy: string;
     mainImage: ImageType;
-    pageSections: PageSectionType;
+    pageSections: PageSectionType[];
   };
 };
 


### PR DESCRIPTION
# Pull Request Process

This PR has two parts:

1) Adds logic for news/insights Post Component section - We are trying to separate mainImage logic from the post. If the first pageSection of a news/insights post is **not** an Images Layout type, then it will show the mainImage. Otherwise, it will resort to previous version which shows the main image. This is to help ensure a smooth transition of image source in Contentful. 

2) The second part is correcting the sorting call for the news/events. It is supposed to be latest date first. 

This will be merged in as two separate commits. 




## Code Review Checklist

<!-- This checklist is for requesters and reviewers  -->

- [ ] Have the package.json or package-lock.json been changed? If so, does the pull request description say why?
- [ ] Has the UI for mobile and desktop been changed, did you test on IphoneXr and desktop views?
- [ ] Does the UI match the requirements in the ticket and designs in figma; does it pass the visual smell test?
- [ ] Have TypeScript files been changed, does the TypeScript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?
